### PR TITLE
Fixed Bug

### DIFF
--- a/CreateGroupTask.java
+++ b/CreateGroupTask.java
@@ -1,0 +1,86 @@
+package com.whatsweb;
+
+import android.os.AsyncTask;
+import android.util.Log;
+
+import org.json.JSONObject;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+public class CreateGroupTask extends AsyncTask{
+
+    protected Object doInBackground(Object... args) {//group json, member json, name, smsnumber
+        JSONObject newGroup = (JSONObject) args[0];
+        JSONObject newMember = (JSONObject) args[1];
+        String name = (String) args[2];
+        String smsNumber = (String) args[3];
+        String createGroupLink = MainActivity.groupMeBaseUrl + "/groups?" + MainActivity.groupMeApiKey;
+        String addMemberLink;
+
+        try {
+            //create group
+            URL newGroupUrl = new URL(createGroupLink);
+            HttpURLConnection createGroupConnection = (HttpURLConnection) newGroupUrl.openConnection();
+            createGroupConnection.setConnectTimeout(5000);
+            createGroupConnection.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
+            createGroupConnection.setDoOutput(true);
+            createGroupConnection.setDoInput(true);
+            createGroupConnection.setRequestMethod("POST");
+            OutputStream newGroupOutputStream = createGroupConnection.getOutputStream();
+            newGroupOutputStream.write(newGroup.toString().getBytes("UTF-8"));
+            newGroupOutputStream.close();
+
+            //response
+            System.out.println("Status: "+createGroupConnection.getResponseCode());
+            InputStream createChatInputStream = new BufferedInputStream(createGroupConnection.getInputStream());
+            BufferedReader streamReader = new BufferedReader(new InputStreamReader(createChatInputStream, "UTF-8"));
+            StringBuilder responseStrBuilder = new StringBuilder();
+            String inputStr;
+            while ((inputStr = streamReader.readLine()) != null) {
+                responseStrBuilder.append(inputStr);
+            }
+            JSONObject newGroupResponse = new JSONObject(responseStrBuilder.toString());
+            JSONObject groupObject=newGroupResponse.getJSONObject("response");
+            String groupID = groupObject.getString("group_id");
+            createGroupConnection.disconnect();
+
+            //add member
+            addMemberLink = MainActivity.groupMeBaseUrl + "/groups/" + groupID + "/members/add?" + MainActivity.groupMeApiKey;
+            URL addMemberUrl = new URL(addMemberLink);
+            HttpURLConnection addMemberConnection = (HttpURLConnection) addMemberUrl.openConnection();
+            addMemberConnection.setConnectTimeout(5000);
+            addMemberConnection.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
+            addMemberConnection.setDoOutput(true);
+            addMemberConnection.setDoInput(true);
+            addMemberConnection.setRequestMethod("POST");
+            OutputStream addMemberOutputStream = addMemberConnection.getOutputStream();
+            addMemberOutputStream.write(newMember.toString().getBytes("UTF-8"));
+            addMemberOutputStream.close();
+
+            System.out.println("Status: "+addMemberConnection.getResponseCode());
+            InputStream addMemberInputStream = new BufferedInputStream(addMemberConnection.getInputStream());
+            BufferedReader addMemberStreamReader = new BufferedReader(new InputStreamReader(addMemberInputStream, "UTF-8"));
+            StringBuilder addMemberStrBuilder = new StringBuilder();
+            String addMemberInputStr;
+            while ((addMemberInputStr = addMemberStreamReader.readLine()) != null) {
+                addMemberStrBuilder.append(addMemberInputStr);
+            }
+
+            addMemberConnection.disconnect();
+
+            MainActivity.groupMeChats.put(name,new GroupInfo(name,smsNumber,groupID));
+
+        } catch (Exception e) {
+            Log.e("CreateGroupTask", e.getMessage(), e);
+        }
+        return null;
+    }
+
+}
+

--- a/DeleteGroupTask.java
+++ b/DeleteGroupTask.java
@@ -1,0 +1,38 @@
+package com.whatsweb;
+
+import android.os.AsyncTask;
+import android.util.Log;
+
+import org.json.JSONObject;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+public class DeleteGroupTask extends AsyncTask{
+
+    protected Object doInBackground(Object... args) {//group
+        GroupInfo groupObject = (GroupInfo) args[0];
+        String deleteGroupLink = MainActivity.groupMeBaseUrl + "/groups/" + groupObject.getGroupID() + "/destroy?" + MainActivity.groupMeApiKey;
+        try {
+            //delete group
+            URL deleteGroupUrl = new URL(deleteGroupLink);
+            HttpURLConnection deleteGroupConnection = (HttpURLConnection) deleteGroupUrl.openConnection();
+            deleteGroupConnection.setConnectTimeout(5000);
+            deleteGroupConnection.setRequestMethod("POST");
+            System.out.println("Status: "+deleteGroupConnection.getResponseCode());
+            deleteGroupConnection.disconnect();
+            //remove from group list
+            MainActivity.groupMeChats.remove(groupObject.getName());
+        } catch (Exception e) {
+            Log.e("DeleteGroupTask", e.getMessage(), e);
+        }
+        return null;
+    }
+
+}
+

--- a/GMail.java
+++ b/GMail.java
@@ -1,0 +1,68 @@
+package com.whatsweb;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Properties;
+
+import javax.mail.Message;
+import javax.mail.MessagingException;
+import javax.mail.Session;
+import javax.mail.Transport;
+import javax.mail.internet.AddressException;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
+
+public class GMail {
+
+    final String emailPort = "587";// gmail's smtp port
+    final String smtpAuth = "true";
+    final String starttls = "true";
+    final String emailHost = "smtp.gmail.com";
+
+    String fromEmail;
+    String fromPassword;
+    String toEmail;
+    String emailSubject;
+    String emailBody;
+
+    Properties emailProperties;
+    Session mailSession;
+    MimeMessage emailMessage;
+
+    public GMail(String fromEmail, String fromPassword,
+                 String toEmail, String emailSubject, String emailBody) {
+        this.fromEmail = fromEmail;
+        this.fromPassword = fromPassword;
+        this.toEmail = toEmail;
+        this.emailSubject = emailSubject;
+        this.emailBody = emailBody;
+
+        emailProperties = System.getProperties();
+        emailProperties.put("mail.smtp.port", emailPort);
+        emailProperties.put("mail.smtp.auth", smtpAuth);
+        emailProperties.put("mail.smtp.starttls.enable", starttls);
+    }
+
+    public MimeMessage createEmailMessage() throws AddressException,
+            MessagingException, UnsupportedEncodingException {
+
+        mailSession = Session.getDefaultInstance(emailProperties, null);
+        emailMessage = new MimeMessage(mailSession);
+
+        emailMessage.setFrom(new InternetAddress(fromEmail, fromEmail));
+        emailMessage.addRecipient(Message.RecipientType.TO,
+                new InternetAddress(toEmail));
+
+        emailMessage.setSubject(emailSubject);
+        emailMessage.setContent(emailBody, "text/html");// for a html email
+        // emailMessage.setText(emailBody);// for a text email
+        return emailMessage;
+    }
+
+    public void sendEmail() throws AddressException, MessagingException {
+        Transport transport = mailSession.getTransport("smtp");
+        transport.connect(emailHost, fromEmail, fromPassword);
+        transport.sendMessage(emailMessage, emailMessage.getAllRecipients());
+        transport.close();
+    }
+
+}

--- a/GroupInfo.java
+++ b/GroupInfo.java
@@ -1,0 +1,97 @@
+package com.whatsweb;
+
+import android.app.Notification;
+import android.app.PendingIntent;
+import android.app.RemoteInput;
+import android.content.Intent;
+import android.os.Bundle;
+import android.util.Log;
+
+public class GroupInfo {
+
+    private String name;
+    private String phoneNumber;
+    private String groupID;
+
+    private Notification notificationReplyObject;
+
+    public GroupInfo(String name, String phoneNumber, String groupID) {
+        this.name=name;
+        this.phoneNumber=phoneNumber;
+        this.groupID=groupID;
+        notificationReplyObject=null;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getPhoneNumber() {
+        return phoneNumber;
+    }
+
+    public void setPhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
+
+    public String getGroupID() {
+        return groupID;
+    }
+
+    public void setGroupID(String groupID) {
+        this.groupID = groupID;
+    }
+
+    public void setNotificationReplyObject(NotificationInfo notification) {
+        if(notification!=null) {
+            Notification.Action replyAction = notification.getReplyAction();
+            if (replyAction != null) {
+                this.notificationReplyObject = notification.getNotificationObject();
+            }
+        }
+    }
+
+    public void setNotificationReplyObject(Notification notification) {
+        if(notification!=null) {
+            Notification.Action replyAction = notification.actions[0];
+            if (replyAction != null) {
+                this.notificationReplyObject = notification;
+            }
+        }
+    }
+
+    public boolean reply(String text) {
+        Notification replyNotification = this.getNotificationReplyObject();
+        RemoteInput[] remoteInputs = replyNotification.actions[0].getRemoteInputs();
+        Intent localIntent = new Intent();
+        localIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        Bundle localBundle = replyNotification.extras;
+        int i = 0;
+        for(RemoteInput remoteIn : remoteInputs){
+            remoteInputs[i] = remoteIn;
+            localBundle.putCharSequence(remoteInputs[i].getResultKey(), text);
+            i++;
+        }
+        RemoteInput.addResultsToIntent(remoteInputs, localIntent, localBundle);
+        try {
+            replyNotification.actions[0].actionIntent.send(NotificationInfo.activity.getApplicationContext(), 0, localIntent);
+            return true;
+        } catch (PendingIntent.CanceledException e) {
+            Log.e("error", "replyToLastNotification error: " + e.getLocalizedMessage());
+            return false;
+        }
+    }
+
+    public Notification getNotificationReplyObject() {
+        return this.notificationReplyObject;
+    }
+
+    public String toString() {
+        return "Group Name: " + this.getName();
+    }
+
+}

--- a/GroupQueryTask.java
+++ b/GroupQueryTask.java
@@ -1,0 +1,148 @@
+package com.whatsweb;
+
+import android.app.Notification;
+import android.os.AsyncTask;
+import android.util.Log;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+
+public class GroupQueryTask extends AsyncTask{
+
+    protected Object doInBackground(Object... args) {
+        try {
+            HashMap<String,GroupInfo> oldGroups= (HashMap<String,GroupInfo>) MainActivity.groupMeChats.clone();
+            MainActivity.groupMeChats.clear();
+            String groupMeGroupQuery = MainActivity.groupMeBaseUrl + "/groups?" + MainActivity.groupMeApiKey;
+            URL groupQueryUrl = new URL(groupMeGroupQuery);
+            HttpURLConnection groupQueryConnection = (HttpURLConnection) groupQueryUrl.openConnection();
+            JSONObject groupQueryJSON;
+            try {
+                System.out.println("Status: "+groupQueryConnection.getResponseCode());
+                InputStream groupQueryInputStream = new BufferedInputStream(groupQueryConnection.getInputStream());
+                BufferedReader streamReader = new BufferedReader(new InputStreamReader(groupQueryInputStream, "UTF-8"));
+                StringBuilder responseStrBuilder = new StringBuilder();
+
+                String inputStr;
+                while ((inputStr = streamReader.readLine()) != null)
+                    responseStrBuilder.append(inputStr);
+
+                groupQueryJSON = new JSONObject(responseStrBuilder.toString());
+            } finally {
+                groupQueryConnection.disconnect();
+            }
+            JSONArray groupArray=groupQueryJSON.getJSONArray("response");
+            for(int i = 0; i<groupArray.length(); i++) {
+                JSONObject group = (JSONObject) groupArray.get(i);
+                String groupName = group.getString("name");
+                String groupDescription = group.getString("description");
+                int numMembers = group.getJSONArray("members").length();
+                int uselessLengthDescription = ("Communicate with ").length();
+                String phoneNumber = groupDescription.substring(uselessLengthDescription);
+                if(groupName.contains(MainActivity.userName + " WhatsWeb with ") && numMembers>1) {
+                    int uselessLengthName = (MainActivity.userName + " WhatsWeb with ").length();
+                    String groupWith = groupName.substring(uselessLengthName);
+                    MainActivity.groupMeChats.put(groupWith,new GroupInfo(groupWith,phoneNumber,group.getString("group_id")));
+                }
+            }
+            for(String groupWithName : MainActivity.groupMeChats.keySet()) {
+                if(groupWithName.contains("Unknown")) {
+                    MainActivity.numGroupsUnknownName++;
+                }
+            }
+            //if no groups found, create one here (hardcoded because can't call AsyncTask from another AsyncTask)
+            if (MainActivity.groupMeChats.size() == 0) {
+                //new group objects
+                JSONObject newGroup = new JSONObject();
+                newGroup.put("name", MainActivity.userName + " WhatsWeb with " + MainActivity.userName);
+                newGroup.put("description", "Communicate with " + MainActivity.phoneNumber);
+                JSONObject clientMember = new JSONObject();
+                clientMember.put("nickname", MainActivity.userName);
+                clientMember.put("phone_number", "+1 " + MainActivity.phoneNumber.substring(1));
+                JSONObject newMember = new JSONObject();
+                JSONArray membersArray = new JSONArray();
+                membersArray.put(clientMember);
+                newMember.put("members", membersArray);
+
+                //create group
+                String name = MainActivity.userName;
+                String smsNumber = MainActivity.phoneNumber;
+                String createGroupLink = MainActivity.groupMeBaseUrl + "/groups?" + MainActivity.groupMeApiKey;
+                URL newGroupUrl = new URL(createGroupLink);
+                HttpURLConnection createGroupConnection = (HttpURLConnection) newGroupUrl.openConnection();
+                createGroupConnection.setConnectTimeout(5000);
+                createGroupConnection.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
+                createGroupConnection.setDoOutput(true);
+                createGroupConnection.setDoInput(true);
+                createGroupConnection.setRequestMethod("POST");
+                OutputStream newGroupOutputStream = createGroupConnection.getOutputStream();
+                newGroupOutputStream.write(newGroup.toString().getBytes("UTF-8"));
+                newGroupOutputStream.close();
+
+                //response
+                System.out.println("Status: "+createGroupConnection.getResponseCode());
+                InputStream createChatInputStream = new BufferedInputStream(createGroupConnection.getInputStream());
+                BufferedReader streamReader = new BufferedReader(new InputStreamReader(createChatInputStream, "UTF-8"));
+                StringBuilder responseStrBuilder = new StringBuilder();
+                String inputStr;
+                while ((inputStr = streamReader.readLine()) != null) {
+                    responseStrBuilder.append(inputStr);
+                }
+                JSONObject newGroupResponse = new JSONObject(responseStrBuilder.toString());
+                JSONObject groupObject=newGroupResponse.getJSONObject("response");
+                String groupID = groupObject.getString("group_id");
+                createGroupConnection.disconnect();
+
+                //add member
+                String addMemberLink = MainActivity.groupMeBaseUrl + "/groups/" + groupID + "/members/add?" + MainActivity.groupMeApiKey;
+                URL addMemberUrl = new URL(addMemberLink);
+                HttpURLConnection addMemberConnection = (HttpURLConnection) addMemberUrl.openConnection();
+                addMemberConnection.setConnectTimeout(5000);
+                addMemberConnection.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
+                addMemberConnection.setDoOutput(true);
+                addMemberConnection.setDoInput(true);
+                addMemberConnection.setRequestMethod("POST");
+                OutputStream addMemberOutputStream = addMemberConnection.getOutputStream();
+                addMemberOutputStream.write(newMember.toString().getBytes("UTF-8"));
+                addMemberOutputStream.close();
+
+                System.out.println("Status: "+addMemberConnection.getResponseCode());
+                InputStream addMemberInputStream = new BufferedInputStream(addMemberConnection.getInputStream());
+                BufferedReader addMemberStreamReader = new BufferedReader(new InputStreamReader(addMemberInputStream, "UTF-8"));
+                StringBuilder addMemberStrBuilder = new StringBuilder();
+                String addMemberInputStr;
+                while ((addMemberInputStr = addMemberStreamReader.readLine()) != null) {
+                    addMemberStrBuilder.append(addMemberInputStr);
+                }
+
+                addMemberConnection.disconnect();
+
+                MainActivity.groupMeChats.put(name,new GroupInfo(name,smsNumber,groupID));
+            }
+            //copy over replies
+            if(oldGroups.size()>0) {
+                for(String groupName : MainActivity.groupMeChats.keySet()) {
+                    if(oldGroups.get(groupName)!=null) {
+                        Notification replyNotification = oldGroups.get(groupName).getNotificationReplyObject();
+                        MainActivity.groupMeChats.get(groupName).setNotificationReplyObject(replyNotification);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            Log.e("GroupQueryTask", e.getMessage(), e);
+        }
+        return null;
+    }
+
+}
+

--- a/MainActivity.java
+++ b/MainActivity.java
@@ -1,0 +1,115 @@
+package com.whatsweb;
+
+import android.accessibilityservice.AccessibilityService;
+import android.annotation.TargetApi;
+import android.app.Activity;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.os.Build;
+import android.os.Bundle;
+import android.provider.Settings;
+import android.text.TextUtils;
+
+import androidx.annotation.RequiresApi;
+import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+
+public class MainActivity extends Activity {
+
+    /* NOTES:
+        1)add OAuth?
+        2)save notification object (1 per group for reply) somewhere to reload on startup (still important?)
+        3)fix delete group; create diagnostics that checks ALL api functionality
+        4)detect and handle media (first from whatsapp, then from client)
+            a)detect picture notification from whatsapp (with emoji); send via mms?
+            b)detect voice message from whatsapp; convert opus to mp3; send via mms or phone call;
+        5)add was sent to client, every time send another loop through missed ones
+        6)on first launch query for username (use as gm identifier), or input on screen
+
+       OPTIMIZATION:
+        1)extend NotificationInfo into 2 separate classes (WhatsApp and GroupMe)
+        2)replace group me app/notifications with url callback
+    */
+
+    public static String phoneEmail;//instead use phone number, either detected or input
+    public static String phoneNumber;
+    public static String userName;//group me
+    public static String groupMeApiKey;
+    public static String groupMeBaseUrl;
+    public static ArrayList<NotificationInfo> receivedMessagesList;
+    public static ArrayList<NotificationInfo> sentMessagesList;//mark as sent and when send new, loop through and send any unsent
+    public static HashMap<String, GroupInfo> groupMeChats;
+    public static int numGroupsUnknownName;
+    NotificationListener notificationListener;
+    WhatsappAccessibilityService whatsappAccessibilityService;
+
+
+    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP_MR1)
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_main);
+        notificationListener = new NotificationListener();
+        whatsappAccessibilityService = new WhatsappAccessibilityService();
+        if (!Settings.Secure.getString(this.getContentResolver(),"enabled_notification_listeners").contains(getApplicationContext().getPackageName())) {
+            startActivity(new Intent(Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS));
+        }
+        while (!Settings.Secure.getString(this.getContentResolver(),"enabled_notification_listeners").contains(getApplicationContext().getPackageName())) {
+
+        }
+        if(ContextCompat.checkSelfPermission(this, android.Manifest.permission.READ_CONTACTS) != PackageManager.PERMISSION_GRANTED) {
+                ActivityCompat.requestPermissions(this,
+                        new String[]{android.Manifest.permission.READ_CONTACTS},
+                        1);
+
+        }
+        while(ContextCompat.checkSelfPermission(this, android.Manifest.permission.READ_CONTACTS) != PackageManager.PERMISSION_GRANTED) {
+            //don't go to next step until contacts permission
+        }
+        Context context=getApplicationContext();
+        if (!isAccessibilityOn (context, WhatsappAccessibilityService.class)) {
+            startActivity(new Intent (Settings.ACTION_ACCESSIBILITY_SETTINGS));
+        }
+        NotificationInfo.activity=this;
+        userName="Moshe Goldberg";
+        phoneEmail="7187875275@messaging.sprintpcs.com";
+        phoneNumber="17187875275";
+        groupMeApiKey="token=IB3lgCtQxHbXfNftJ5lS8MJemwyEKgonLDQq6uDu";//m6rfsk8wVk2ZPa10w36GL1LYcSz7bDhGIzzec470 (old)
+        groupMeBaseUrl="https://api.groupme.com/v3";
+        groupMeChats = new  HashMap<String, GroupInfo>();
+        numGroupsUnknownName=0;
+        new GroupQueryTask().execute();
+    }
+
+    public boolean isAccessibilityOn (Context context, Class<? extends AccessibilityService> clazz) {
+        int accessibilityEnabled = 0;
+        final String service = context.getPackageName () + "/" + clazz.getCanonicalName ();
+        try {
+            accessibilityEnabled = Settings.Secure.getInt (context.getApplicationContext ().getContentResolver (), Settings.Secure.ACCESSIBILITY_ENABLED);
+        } catch (Settings.SettingNotFoundException ignored) {  }
+
+        TextUtils.SimpleStringSplitter colonSplitter = new TextUtils.SimpleStringSplitter(':');
+
+        if (accessibilityEnabled == 1) {
+            String settingValue = Settings.Secure.getString (context.getApplicationContext().getContentResolver (), Settings.Secure.ENABLED_ACCESSIBILITY_SERVICES);
+            if (settingValue != null) {
+                colonSplitter.setString (settingValue);
+                while (colonSplitter.hasNext ()) {
+                    String accessibilityService = colonSplitter.next ();
+
+                    if (accessibilityService.equalsIgnoreCase (service)) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/NotificationInfo.java
+++ b/NotificationInfo.java
@@ -1,0 +1,471 @@
+package com.whatsweb;
+
+import android.app.Activity;
+import android.app.Notification;
+import android.content.ContentResolver;
+import android.content.Intent;
+import android.database.Cursor;
+import android.provider.ContactsContract;
+import android.util.Log;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.Arrays;
+
+public class NotificationInfo {
+
+    private String title;
+    private String text;
+    private String app;
+    private long when;
+    private Notification.Action replyAction;
+    private Notification notificationObject;
+
+    private String to;
+    private String from;
+    private GroupInfo groupObject;
+    public boolean wasSent;
+    public boolean forProgramOnly;
+
+    public static Activity activity;
+
+    public  NotificationInfo(String app, String title, String text, long when, Notification notificationObject) throws JSONException, InterruptedException {
+        this.title=title;
+        this.text=text;
+        this.app=app;
+        this.when=when;
+        this.wasSent=false;
+        this.notificationObject=notificationObject;
+        this.forProgramOnly=false;
+        if(app.equals("com.whatsapp")) {//handle phone num not in contacts
+            //save reply object
+            if(notificationObject.actions!=null) {
+                Notification.Action reply = notificationObject.actions[0];
+                this.setReplyAction(reply);
+            }
+            //parse group chat title
+            if(title.contains(":")) {
+                int colonIndex = this.title.indexOf(":");
+                String sender = this.title.substring(colonIndex+2);
+                this.text = sender + ": " + this.text;
+                this.title = this.title.substring(0,colonIndex);
+                if(this.title.contains("messages)")) {
+                    this.title=this.title.substring(0,this.title.lastIndexOf("("));
+                }
+                //sometimes group messages register with last char as " "
+                if(this.title.charAt(this.title.length()-1)==' ') {
+                    this.title=this.title.substring(0,this.title.length()-1);
+                }
+            }
+            String contactsSms = getContactsNumber(this.getTitle());
+            this.groupObject=getGroup(this.getTitle(),contactsSms);
+            if(groupObject==null) {
+                if(contactsSms==null) {
+                    contactsSms = this.title;
+                }
+                createNewGroup(this.title,contactsSms);
+                Thread.sleep(2500);
+                this.groupObject=getGroup(this.getTitle(),contactsSms);
+                String firstMessage="This group connects to the WhatsApp chat, \""
+                         + this.getTitle() + "\". The first text you send on this chat will not be sent to WhatsApp.";
+                sendGroupMeMessage(firstMessage,this.groupObject);
+            }
+        } else if(app.equals("com.groupme.android")) {
+            if(!this.getTitle().contains(MainActivity.userName+" WhatsWeb with")) {
+                this.wasSent=true;//message not intended for this client
+            }
+            this.text = this.getText().substring(this.getText().indexOf(':')+2);//their name in chat isnt important
+            /////////////////parse////////////////////////
+            int uselessLengthName = (MainActivity.userName + " WhatsWeb with ").length();
+            this.setTitle(this.getTitle().substring(uselessLengthName));
+            this.groupObject=getGroup(this.getTitle());
+            String smsNumber = null;
+            if(this.groupObject!=null) {
+                smsNumber=groupObject.getPhoneNumber();
+            }
+            if(smsNumber!=null && smsNumber.length()==10) {
+                smsNumber = "1" + smsNumber;
+            }
+            String message = this.getText();
+            if(this.getText().length()>1 && this.getText().charAt(0)=='@') {
+                String possibleMessage = isMeantForProgram(this.getText().substring(1));
+                if(possibleMessage!=null) {
+                    this.setText(possibleMessage);
+                    this.forProgramOnly=true;
+                    handleAsProgramMessage();
+                }
+            }
+            if(this.getText().length()>1 && this.getText().charAt(0)=='@' && !forProgramOnly) {
+                String[] textAsArray = this.getText().substring(1).split(" ",-1);
+                String name = "";
+                for(String wordOfText : textAsArray) {
+                    if(isPhoneNumber(wordOfText)) {
+                        smsNumber=wordOfText;
+                        break;
+                    } else {
+                        name += wordOfText+" ";
+                    }
+                }
+                if(name.length()>=1) {
+                    //get rid of extra space added at end
+                    name = name.substring(0, name.length() - 1);
+                }
+                //exceptions
+                if(Arrays.equals(name.split(" ", -1), textAsArray)) {
+                    //if no number
+                    if(name.contains("(")&&name.contains(")")) {
+                        name=name.substring(name.indexOf("("),name.indexOf(")")+1);
+                    }
+                    if(name.contains("[")&&name.contains("]")) {
+                        name=name.substring(name.indexOf("["),name.indexOf("]")+1);
+                    }
+                }
+                if(name.equals("")) {
+                    //if no name before number
+                    name = "Unknown " + (MainActivity.numGroupsUnknownName + 1);
+                }
+                message=message.substring(message.indexOf(smsNumber)+smsNumber.length());
+                this.setText(message);
+                if((name.charAt(0)=='('&&name.charAt(name.length()-1)==')')||(name.charAt(0)=='['&&name.charAt(name.length()-1)==']')) {
+                    //take ()[] out of name (kept out of message earlier)
+                    name=name.substring(1,name.length()-1);
+                    String potentialSMS = getContactsNumber(name);
+                    if(potentialSMS!=null) {
+                        smsNumber=potentialSMS;
+                    } else {
+                        smsNumber=name;
+                    }
+                }
+                //take out dashes
+                if(smsNumber.length()==10) {
+                    smsNumber = "1" + smsNumber;
+                }
+                GroupInfo possibleGroup=getGroup(name,smsNumber);
+                if(possibleGroup!=null) {
+                    this.groupObject=possibleGroup;
+                } else {
+                    createNewGroup(name,smsNumber);
+                    Thread.sleep(2500);
+                    this.groupObject=getGroup(name,smsNumber);
+                    String firstMessage="This group connects to the WhatsApp chat, \""
+                            + name + "\". The first text you send on this chat will not be sent to WhatsApp.";
+                    sendGroupMeMessage(firstMessage,this.groupObject);
+                }
+            }
+            if(!forProgramOnly) {
+                this.setTo(smsNumber);
+                this.setText(message); //redundant?
+            }
+            //Log.v("smsNumber",smsNumber);
+        }
+        //System.out.println(this.groupObject);
+        //Log.v("when", Long.toString(notificationObject.when));
+    }
+
+    private void handleAsProgramMessage() throws JSONException, InterruptedException {
+        String queryMessage = this.getText();
+        switch (queryMessage) {
+            case "test":
+                this.setText("WhatsWeb is working.");
+                break;
+            case "diagnostics": case "info":
+                //include more info
+                this.setText("Program is running. You have " + MainActivity.groupMeChats.size() + " WhatsWeb chats.");
+                break;
+            case "awake":
+                this.setText("Wide awake, in fact. Have a good morning (or whatever time of day it is).");
+                break;
+            case "respond":
+                this.setText("response.");
+                break;
+            case "ping":
+                this.setText("Pong!");
+                break;
+            case "getgroup": case "getgroupname": case "groupname": case "getname":
+                this.setText("This group connects you with the WhatsApp chat, \"" + this.groupObject.getName() + "\".");
+                break;
+            case "refresh": case "refreshchats": case "refreshgroups":
+                new GroupQueryTask().execute();
+                this.setText("Refreshing...");
+                break;
+            case "deletegroup": case "delete": case "deletechat": case "destroy":
+                System.out.println("Deleting chat");
+                new DeleteGroupTask().execute(this.groupObject);
+                Thread.sleep(5000);
+                new GroupQueryTask().execute();
+                break;
+        }
+        if(!queryMessage.equals("deletegroup") && !queryMessage.equals("delete") && !queryMessage.equals("deletechat")) {
+            this.sendToUser();
+        }
+    }
+
+    private String isMeantForProgram(String message) {
+        message = message.toLowerCase();
+        String tempMessage = "";
+        for(int i = 0; i<message.length(); i++) {
+            if("abcdefghijklmnopqrstuvwxyz1234567890".contains(Character.toString(message.charAt(i)))) {
+                tempMessage+=message.charAt(i);
+            }
+        }
+        message=tempMessage;
+        //add change name and number
+        if(message.equals("deletegroup") || message.equals("deletechat") || message.equals("delete") || message.equals("test")
+                || message.equals("diagnostics") || message.equals("info") || message.equals("destroy")
+                || message.equals("awake") || message.equals("respond") || message.equals("ping")
+                || message.equals("refresh") || message.equals("refreshchats") || message.equals("refreshgroups")
+                || message.equals("getgroup") || message.equals("getgroupname") || message.equals("groupname") || message.equals("getname")) {
+            return message;
+        }
+        return null;
+    }
+
+    private String getContactsNumber(String title) {
+        //put code to find contact's number based on name here
+
+        ContentResolver contentResolver = activity.getContentResolver();
+        //String[] projection = new String[] {ContactsContract.Contacts.DISPLAY_NAME, ContactsContract.CommonDataKinds.Phone.NUMBER};
+        Cursor cursor = activity.getContentResolver().query(ContactsContract.Contacts.CONTENT_URI, null, null, null, null);
+        while (cursor.moveToNext()) {
+            try{
+                String contactId = cursor.getString(cursor.getColumnIndex(ContactsContract.Contacts._ID));
+                String name = cursor.getString(cursor.getColumnIndex(ContactsContract.Contacts.DISPLAY_NAME));
+                String hasPhone = cursor.getString(cursor.getColumnIndex(ContactsContract.Contacts.HAS_PHONE_NUMBER));
+                if (Integer.parseInt(hasPhone) > 0 && name.equalsIgnoreCase(title)) {
+                    Cursor phones = contentResolver.query( ContactsContract.CommonDataKinds.Phone.CONTENT_URI, null, ContactsContract.CommonDataKinds.Phone.CONTACT_ID +" = "+ contactId, null, null);
+                    while (phones.moveToNext()) {
+                        String phoneNumber = phones.getString(phones.getColumnIndex( ContactsContract.CommonDataKinds.Phone.NUMBER));
+                        //Is this necessary?
+                        if(phoneNumber==null) {
+                            continue;
+                        }
+                        if(phoneNumber.charAt(0)=='+') {
+                            phoneNumber=phoneNumber.substring(1);
+                        }
+                        if(phoneNumber.length()==10) {
+                            phoneNumber = "1" + phoneNumber;
+                        }
+                        Log.v("Found phone in contacts",phoneNumber);
+                        return  phoneNumber;
+                    }
+                    phones.close();
+                }
+            }catch(Exception e){
+                return null;
+            }
+        }
+
+        return null;
+    }
+
+    private GroupInfo getGroup(String name, String sms) {
+        if(sms==null) {
+            return getGroup(name);
+        }
+        GroupInfo groupBySMS = getSmsInChat(sms);
+        if(groupBySMS!=null) {
+            return groupBySMS;
+        }
+        return getGroup(name);
+    }
+
+    private GroupInfo getGroup(String name) {
+        //find CLOSEST if more than one match contain criteria!!!
+        for(GroupInfo group : MainActivity.groupMeChats.values()) {
+            if(name.toLowerCase().contains(group.getName().toLowerCase())) {
+                //assume contacts (WhatsApp) has fuller name
+                return group;
+            }
+        }
+        //test out:
+        if (name.indexOf("+")==0 && name.indexOf(" ")==2 && name.indexOf("(")==3 && name.indexOf(")")==7) {//could add more tests if necessary
+            String tempSMS = "";
+            //just get numbers
+            for(int i = 0; i<name.length(); i++) {
+                String index = Character.toString(name.charAt(i));
+                if("0123456789".contains(index)) {
+                    tempSMS += index;
+                }
+            }
+            for(GroupInfo group : MainActivity.groupMeChats.values()) {
+                if(group.getPhoneNumber().equals(tempSMS)) {
+                    return group;
+                }
+            }
+        }
+        return null;
+    }
+
+    private GroupInfo getSmsInChat(String sms) {
+        for(String name : MainActivity.groupMeChats.keySet()) {
+            GroupInfo tempGroup = MainActivity.groupMeChats.get(name);
+            if(tempGroup.getPhoneNumber().equals(sms)) {
+                return tempGroup;
+            }
+        }
+        return null;
+    }
+
+    public void sendToWhatsApp() {
+        //add catch for number to existing (and no avail reply) to notify user that msg did not go through
+        if(this.groupObject!=null&&this.groupObject.getNotificationReplyObject()!=null) {
+            this.wasSent=this.groupObject.reply(this.getText());
+        } else if (isPhoneNumber(this.getTo())) {
+            Intent sendIntent = new Intent(Intent.ACTION_SEND);
+            sendIntent.setType("text/plain");
+            sendIntent.putExtra(Intent.EXTRA_TEXT, this.getText());
+            sendIntent.putExtra("jid", this.getTo() + "@s.whatsapp.net"); //phone number without "+" prefix
+            sendIntent.setPackage("com.whatsapp");
+            activity.startActivity(sendIntent);
+        }
+    }
+
+    public void sendToUser() throws JSONException {
+        GroupInfo groupWith = this.groupObject;
+        String message = this.getText();
+        if(groupWith==null) {
+            System.out.println("no group found");
+            groupWith = getGroup(MainActivity.userName);
+            message = this.getTitle() + ": " + this.getText();//only if cant create new chat
+        }
+        if(groupWith!=null) {
+            sendGroupMeMessage(message,groupWith);
+            //if no group created doesn't add to reply action of default group
+            if(message.equals(this.getText())) {
+                groupWith.setNotificationReplyObject(this);
+            }
+        } else {//if no username chat instantiated, use email (if uses this, api key may have changed)
+            String fromEmail = "whatswebtext@gmail.com";
+            String fromPassword = "ChoneinHadaas425";
+            String toEmail = MainActivity.phoneEmail;
+            String emailSubject = "";
+            String emailBody = this.title + ": " + this.text;
+            new SendMailTask().execute(fromEmail, fromPassword, toEmail, emailSubject, emailBody);
+        }
+        this.wasSent=true;
+    }
+
+    private boolean isPhoneNumber(String potentialPhoneNumber) {
+        //take out dashes
+        if(potentialPhoneNumber.length()<10||potentialPhoneNumber.length()>11) {
+            return false;
+        }
+        for(int i = 0; i<potentialPhoneNumber.length(); i++) {
+            if(!"0123456789".contains(Character.toString(potentialPhoneNumber.charAt(i)))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private void createNewGroup(String name, String smsNumber) throws JSONException {
+        JSONObject newGroup = new JSONObject();
+        newGroup.put("name", MainActivity.userName + " WhatsWeb with " + name);
+        newGroup.put("description", "Communicate with " + smsNumber);
+        JSONObject clientMember = new JSONObject();
+        clientMember.put("nickname", MainActivity.userName);
+        clientMember.put("phone_number", "+1 "+ MainActivity.phoneNumber.substring(1));
+        JSONObject memberObject = new JSONObject();
+        JSONArray membersArray = new JSONArray();
+        membersArray.put(clientMember);
+        memberObject.put("members", membersArray);
+        System.out.println(memberObject.toString());
+        new CreateGroupTask().execute(newGroup,memberObject,name,smsNumber);
+    }
+
+    private void sendGroupMeMessage(String text, GroupInfo group) throws JSONException {
+        JSONObject messageObject = new JSONObject();
+        messageObject.put("source_guid", Long.toString(this.getWhen()));
+        messageObject.put("text", text);
+        JSONObject messageObjectWrapper = new JSONObject();
+        messageObjectWrapper.put("message", messageObject);
+        new SendGroupMeTask().execute(messageObjectWrapper, group);
+        //to allow new source_guid for potential subsequent messages
+        this.when+=1;
+    }
+
+    // Generic Methods
+
+    public void print() {
+        Log.v("title", this.title);
+        Log.v("text", this.text);
+        Log.v("app", this.app);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        NotificationInfo that = (NotificationInfo) o;
+        if(this.getApp().equals(that.getApp())&&this.getTitle().equals(that.getTitle())
+                &&this.getText().equals(that.getText())&&Math.abs(this.when-that.when) < (long) 10000) {
+            return true;
+        } else if(this.getWhen()==that.getWhen()) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public Notification.Action getReplyAction() {
+        return replyAction;
+    }
+
+    public void setReplyAction(Notification.Action replyAction) {
+        this.replyAction = replyAction;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+
+    public String getApp() {
+        return app;
+    }
+
+    public void setApp(String app) {
+        this.app = app;
+    }
+
+    public String getTo() {
+        return to;
+    }
+
+    public void setTo(String to) {
+        this.to = to;
+    }
+
+    public String getFrom() {
+        return from;
+    }
+
+    public void setFrom(String from) {
+        this.from = from;
+    }
+
+    public long getWhen() {
+        return when;
+    }
+
+    public Notification getNotificationObject() {
+        return notificationObject;
+    }
+
+    public void setNotificationObject(Notification notificationObject) {
+        this.notificationObject = notificationObject;
+    }
+}

--- a/NotificationListener.java
+++ b/NotificationListener.java
@@ -1,0 +1,77 @@
+package com.whatsweb;
+
+import android.app.Notification;
+import android.content.Context;
+import android.service.notification.NotificationListenerService;
+import android.service.notification.StatusBarNotification;
+import android.util.Log;
+
+import java.util.ArrayList;
+
+public class NotificationListener extends NotificationListenerService {
+
+    Context context;
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        context = getApplicationContext();
+        MainActivity.receivedMessagesList = new ArrayList<NotificationInfo>();
+        MainActivity.sentMessagesList = new ArrayList<NotificationInfo>();
+    }
+
+    @Override
+    public void onNotificationPosted(StatusBarNotification sbn) {
+        try {
+            Notification notificationObject = sbn.getNotification();
+            String title = notificationObject.extras.getCharSequence(Notification.EXTRA_TITLE).toString();
+            String text = notificationObject.extras.getCharSequence(Notification.EXTRA_TEXT).toString();
+            String package_name = sbn.getPackageName();
+            if(!isUselessMessage(text) && !title.contains("You") && !isUselessMessage(title)) {
+                NotificationInfo newNotification = new NotificationInfo(package_name, title, text, notificationObject.when, notificationObject);
+                //Log.v("title", newNotification.getTitle());
+                Log.v("text", newNotification.getText());
+                if(newNotification.getApp().equals("com.whatsapp") && !newNotification.forProgramOnly &&
+                        (MainActivity.receivedMessagesList.size() == 0 || !notificationWasSent(newNotification, MainActivity.receivedMessagesList) )) {
+                    newNotification.sendToUser();
+                    MainActivity.receivedMessagesList.add(newNotification);
+                    if(MainActivity.receivedMessagesList.size()>=20) {
+                        MainActivity.receivedMessagesList.remove(0);
+                    }
+                } else if(newNotification.getApp().equals("com.groupme.android") && !newNotification.forProgramOnly) {
+                    if((MainActivity.sentMessagesList.size() == 0 || !notificationWasSent(newNotification, MainActivity.sentMessagesList))) {
+                        newNotification.sendToWhatsApp();
+                        MainActivity.sentMessagesList.add(newNotification);
+                        if(MainActivity.sentMessagesList.size()>=20) {
+                            MainActivity.sentMessagesList.remove(0);
+                        }
+                    }
+                }
+            }
+            //max notifications is 50 on emulator
+            cancelNotification(sbn.getKey());
+        } catch(Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public boolean isUselessMessage(String message) {
+        if(message.toLowerCase().contains("backup in progress") || message.contains("new messages") || message.contains("Ongoing voice call")
+                || (message.contains("messages from")&&message.contains("chats")) ||
+                (message.length()>17&&message.substring(0,17).equals("Deleting messages"))) {
+            return true;
+        }
+        return false;
+    }
+
+    public boolean notificationWasSent(NotificationInfo newNotification, ArrayList<NotificationInfo> notificationList) {//handle 2nd is replyable (replace original)
+        //change to check against individual groups messages
+        for(NotificationInfo notification : notificationList) {
+            if(newNotification.equals(notification) && notification.wasSent) {
+                return true;
+            }
+        }
+        return false;
+    }
+}
+

--- a/SendGroupMeTask.java
+++ b/SendGroupMeTask.java
@@ -1,0 +1,56 @@
+package com.whatsweb;
+
+import android.os.AsyncTask;
+import android.util.Log;
+
+import org.json.JSONObject;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+public class SendGroupMeTask extends  AsyncTask{
+
+    protected Object doInBackground(Object... args) {
+        JSONObject messageObject = (JSONObject) args[0];
+        GroupInfo group = (GroupInfo) args[1];
+        String sendMessageLink;
+        try {
+            sendMessageLink = MainActivity.groupMeBaseUrl + "/groups/" + group.getGroupID() + "/messages?" + MainActivity.groupMeApiKey;
+            URL sendMessageUrl = new URL(sendMessageLink);
+            HttpURLConnection sendMessageConnection = (HttpURLConnection) sendMessageUrl.openConnection();
+            sendMessageConnection.setConnectTimeout(5000);
+            sendMessageConnection.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
+            sendMessageConnection.setDoOutput(true);
+            sendMessageConnection.setDoInput(true);
+            sendMessageConnection.setRequestMethod("POST");
+            OutputStream sendMessageOutputStream = sendMessageConnection.getOutputStream();
+            sendMessageOutputStream.write(messageObject.toString().getBytes("UTF-8"));
+            sendMessageOutputStream.close();
+
+            //response
+            System.out.println("Status: "+sendMessageConnection.getResponseCode());
+            InputStream in = sendMessageConnection.getInputStream();
+            InputStream sendMessageInputStream = new BufferedInputStream(in);
+            BufferedReader sendMessageStreamReader = new BufferedReader(new InputStreamReader(sendMessageInputStream, "UTF-8"));
+            StringBuilder sendMessageStrBuilder = new StringBuilder();
+            String sendMessageInputStr;
+            while ((sendMessageInputStr = sendMessageStreamReader.readLine()) != null) {
+                sendMessageStrBuilder.append(sendMessageInputStr);
+            }
+            JSONObject sendMessageResponse = new JSONObject(sendMessageStrBuilder.toString());
+            System.out.println(sendMessageResponse.toString());
+
+            sendMessageConnection.disconnect();
+        } catch (Exception e) {
+            Log.e("SendGroupMeTask", e.getMessage(), e);
+        }
+        return null;
+    }
+
+}
+

--- a/SendMailTask.java
+++ b/SendMailTask.java
@@ -1,0 +1,22 @@
+package com.whatsweb;
+
+import android.os.AsyncTask;
+import android.util.Log;
+
+public class SendMailTask extends AsyncTask {
+
+    protected Object doInBackground(Object... args) {
+        try {
+            GMail androidEmail = new GMail(args[0].toString(),
+                    args[1].toString(), args[2].toString(), args[3].toString(),
+                    args[4].toString());
+            androidEmail.createEmailMessage();
+            androidEmail.sendEmail();
+        } catch (Exception e) {
+            Log.e("SendMailTask", e.getMessage(), e);
+        }
+        return null;
+    }
+
+}
+

--- a/WhatsappAccessibilityService.java
+++ b/WhatsappAccessibilityService.java
@@ -1,0 +1,73 @@
+package com.whatsweb;
+
+import android.accessibilityservice.AccessibilityService;
+import android.view.accessibility.AccessibilityEvent;
+import android.view.accessibility.AccessibilityNodeInfo;
+
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat;
+
+import java.util.List;
+
+public class WhatsappAccessibilityService extends AccessibilityService {
+
+    @Override
+    public void onAccessibilityEvent (AccessibilityEvent event) {
+        if (getRootInActiveWindow () == null) {
+            return;
+        }
+
+        AccessibilityNodeInfoCompat rootInActiveWindow = AccessibilityNodeInfoCompat.wrap (getRootInActiveWindow ());
+
+        // Whatsapp Message EditText id
+        List<AccessibilityNodeInfoCompat> messageNodeList = rootInActiveWindow.findAccessibilityNodeInfosByViewId ("com.whatsapp:id/entry");
+        if (messageNodeList == null || messageNodeList.isEmpty ()) {
+            return;
+        }
+
+        // check if the whatsapp message EditText field is filled with text
+        AccessibilityNodeInfoCompat messageField = messageNodeList.get(0);
+        boolean messageInPlace=false;
+        NotificationInfo currentNotification = null;
+        for(NotificationInfo notification : MainActivity.sentMessagesList) {
+            if(messageField.getText().toString().equals(notification.getText()) && !notification.wasSent) {
+                messageInPlace=true;
+                currentNotification=notification;
+                notification.wasSent=true;
+                break;
+            }
+        }
+        if (messageField.getText() == null || messageField.getText().length() == 0 || !messageInPlace) {
+            return;
+        }
+
+        // Whatsapp send button id
+        List<AccessibilityNodeInfoCompat> sendMessageNodeInfoList = rootInActiveWindow.findAccessibilityNodeInfosByViewId ("com.whatsapp:id/send");
+        if (sendMessageNodeInfoList == null || sendMessageNodeInfoList.isEmpty ()) {
+            return;
+        }
+
+        AccessibilityNodeInfoCompat sendMessageButton = sendMessageNodeInfoList.get(0);
+        if (!sendMessageButton.isVisibleToUser ()) {
+            return;
+        }
+
+        // Now fire a click on the send button
+        sendMessageButton.performAction(AccessibilityNodeInfo.ACTION_CLICK);
+        currentNotification.wasSent=true;
+
+        // Now go back to your app by clicking on the Android back button twice:
+        // First one to leave the conversation screen
+        // Second one to leave whatsapp
+        try {
+            Thread.sleep(500); // hack for certain devices in which the immediate back click is too fast to handle
+            performGlobalAction (GLOBAL_ACTION_BACK);
+            //Thread.sleep(500);  // same hack as above
+        } catch (InterruptedException ignored) {}
+        performGlobalAction(GLOBAL_ACTION_BACK);
+    }
+
+    @Override
+    public void onInterrupt() {
+
+    }
+}


### PR DESCRIPTION
Fixed a bug in which refreshing (and by extension, deleting) a chat removed the ability to reply to other chats via the Notification Reply Method (only allowing Accessibility Method which doesn't work for group chats and seems to be less stable). 

This was due to the methodology in which MainActivity.groupMeChats was completely rewritten and replaced in GroupQueryTask, without saving reply objects. 

Solved by copying over all available reply objects to new MainActivity.groupMeChats in GroupQueryTask.