### PR TITLE
Client can now receive images sent to WhatsApp

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.READ_CONTACTS"/>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
     <application
         android:allowBackup="true"

--- a/main/java/com/whatsweb/GMail.java
+++ b/main/java/com/whatsweb/GMail.java
@@ -1,15 +1,25 @@
 package com.whatsweb;
 
+import android.os.Environment;
+
+import java.io.File;
 import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
 import java.util.Properties;
 
+import javax.activation.DataHandler;
+import javax.activation.DataSource;
+import javax.activation.FileDataSource;
 import javax.mail.Message;
 import javax.mail.MessagingException;
+import javax.mail.Multipart;
 import javax.mail.Session;
 import javax.mail.Transport;
 import javax.mail.internet.AddressException;
 import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMessage;
+import javax.mail.internet.MimeMultipart;
 
 public class GMail {
 
@@ -19,22 +29,25 @@ public class GMail {
     final String emailHost = "smtp.gmail.com";
 
     String fromEmail;
+    String fromName;
     String fromPassword;
     String toEmail;
     String emailSubject;
     String emailBody;
+    File attachment;
 
     Properties emailProperties;
     Session mailSession;
     MimeMessage emailMessage;
 
-    public GMail(String fromEmail, String fromPassword,
-                 String toEmail, String emailSubject, String emailBody) {
+    public GMail(String fromEmail, String fromName, String fromPassword, String toEmail, String emailSubject, String emailBody, File attachment) {
         this.fromEmail = fromEmail;
+        this.fromName = fromName;
         this.fromPassword = fromPassword;
         this.toEmail = toEmail;
         this.emailSubject = emailSubject;
         this.emailBody = emailBody;
+        this.attachment = attachment;
 
         emailProperties = System.getProperties();
         emailProperties.put("mail.smtp.port", emailPort);
@@ -42,23 +55,30 @@ public class GMail {
         emailProperties.put("mail.smtp.starttls.enable", starttls);
     }
 
-    public MimeMessage createEmailMessage() throws AddressException,
-            MessagingException, UnsupportedEncodingException {
+    public MimeMessage createEmailMessage() throws MessagingException, UnsupportedEncodingException {
 
         mailSession = Session.getDefaultInstance(emailProperties, null);
         emailMessage = new MimeMessage(mailSession);
 
-        emailMessage.setFrom(new InternetAddress(fromEmail, fromEmail));
-        emailMessage.addRecipient(Message.RecipientType.TO,
-                new InternetAddress(toEmail));
+        emailMessage.setFrom(new InternetAddress(fromEmail,fromName));
+        emailMessage.addRecipient(Message.RecipientType.TO, new InternetAddress(toEmail));
 
         emailMessage.setSubject(emailSubject);
-        emailMessage.setContent(emailBody, "text/html");// for a html email
-        // emailMessage.setText(emailBody);// for a text email
+        if(this.attachment==null) {
+            emailMessage.setContent(emailBody, "text/html");// for a html email
+        } else {
+            MimeBodyPart attachmentBodyPart = new MimeBodyPart();
+            DataSource fileSource = new FileDataSource(this.attachment);
+            attachmentBodyPart.setDataHandler(new DataHandler(fileSource));
+            attachmentBodyPart.setFileName("WhatsApp Image");
+            Multipart multipart = new MimeMultipart();
+            multipart.addBodyPart(attachmentBodyPart);
+            emailMessage.setContent(multipart);
+        }
         return emailMessage;
     }
 
-    public void sendEmail() throws AddressException, MessagingException {
+    public void sendEmail() throws MessagingException {
         Transport transport = mailSession.getTransport("smtp");
         transport.connect(emailHost, fromEmail, fromPassword);
         transport.sendMessage(emailMessage, emailMessage.getAllRecipients());

--- a/main/java/com/whatsweb/MainActivity.java
+++ b/main/java/com/whatsweb/MainActivity.java
@@ -1,5 +1,6 @@
 package com.whatsweb;
 
+import android.Manifest;
 import android.accessibilityservice.AccessibilityService;
 import android.app.Activity;
 import android.content.Context;
@@ -23,14 +24,19 @@ import java.util.HashMap;
 
 public class MainActivity extends Activity {
 
-    /* NOTES:
+    /*
+       BUGS:
+        1)Crashes when Fox Notification is picture
+
+       NOTES:
+        !)use date to track images that client has received or not received
+        *)Convert all names to Proper Case
         0)fix (alleged?) glitch in which incoming calls create new groups (even if one exists)
         1)add OAuth?
         2)save notification object (1 per group for reply) somewhere to reload on startup (still important?)
         3)create diagnostics that checks ALL api functionality (with test account, message user where fail in catch)
         4)detect and handle media (first from whatsapp, then from client)
-            a)detect picture notification from whatsapp (with emoji); send via mms?
-            b)detect voice message from whatsapp; convert opus to mp3; send via mms or phone call;
+            a)detect voice message from whatsapp; convert opus to mp3; send via mms or phone call;
         5)add was sent to client, every time send another loop through missed ones
         6)save username and info after first login
 
@@ -74,6 +80,15 @@ public class MainActivity extends Activity {
         }
         while(ContextCompat.checkSelfPermission(this, android.Manifest.permission.READ_CONTACTS) != PackageManager.PERMISSION_GRANTED) {
             //don't go to next step until contacts permission
+        }
+        if(ContextCompat.checkSelfPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
+            ActivityCompat.requestPermissions(this,
+                    new String[]{Manifest.permission.READ_EXTERNAL_STORAGE},
+                    1);
+
+        }
+        while(ContextCompat.checkSelfPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
+            //don't go to next step until read files permission
         }
         Context context=getApplicationContext();
         if (!isAccessibilityOn (context, WhatsappAccessibilityService.class)) {

--- a/main/java/com/whatsweb/SendGroupMeTask.java
+++ b/main/java/com/whatsweb/SendGroupMeTask.java
@@ -16,10 +16,10 @@ import java.net.URL;
 public class SendGroupMeTask extends  AsyncTask{
 
     protected Object doInBackground(Object... args) {
-        JSONObject messageObject = (JSONObject) args[0];
-        GroupInfo group = (GroupInfo) args[1];
-        String sendMessageLink;
         try {
+            JSONObject messageObject = (JSONObject) args[0];
+            GroupInfo group = (GroupInfo) args[1];
+            String sendMessageLink;
             sendMessageLink = MainActivity.groupMeBaseUrl + "/groups/" + group.getGroupID() + "/messages?" + MainActivity.groupMeApiKey;
             URL sendMessageUrl = new URL(sendMessageLink);
             HttpURLConnection sendMessageConnection = (HttpURLConnection) sendMessageUrl.openConnection();

--- a/main/java/com/whatsweb/SendMailTask.java
+++ b/main/java/com/whatsweb/SendMailTask.java
@@ -3,13 +3,15 @@ package com.whatsweb;
 import android.os.AsyncTask;
 import android.util.Log;
 
+import java.io.File;
+
 public class SendMailTask extends AsyncTask {
 
     protected Object doInBackground(Object... args) {
         try {
             GMail androidEmail = new GMail(args[0].toString(),
                     args[1].toString(), args[2].toString(), args[3].toString(),
-                    args[4].toString());
+                    args[4].toString(), args[5].toString() ,(File) args[6]);
             androidEmail.createEmailMessage();
             androidEmail.sendEmail();
         } catch (Exception e) {


### PR DESCRIPTION
Sends the client the most recent WhatsApp image 1500 milliseconds after notification indicates user was sent image on WhatsApp.

Problems to address in future updates:
1) Multiple images sent together (Solution: keep track of sent images and send all that were not sent)
2) Images not download right away (Solution: same as 1)
3) Large images take a long time to send (Solution: compress image) 

